### PR TITLE
Refacto makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+*~
+#*#
+.#*
+*mdr*
+*lol*
+*.a
+*.o
+*.so
+node_modules
+fita

--- a/Makefile
+++ b/Makefile
@@ -4,44 +4,49 @@
 ##
 ##
 
-CC			=		gcc
+CC		=	gcc
 
-CFLAGS		+=		-I include -Wall -Wextra -W -g3
+CFLAGS		+=	-I $(DIRINC)	\
+			-Wall -Wextra -W	\
+			-g
 
-LDFLAGS	+=		-lncurses
+LDFLAGS		+=	-lncurses
 
-DIRLIB		+=		./lib/
+DIRLIB		+=	./lib/
 
-DIRSRC		+=		./src/
+DIRSRC		+=	./src/
 
+DIRINC		+=	./include/
 
-SRC		+=		$(DIRLIB)paths.c			\
-					$(DIRLIB)readline.c		\
-					$(DIRLIB)objects/*.c		\
-					$(DIRSRC)core/files.c		\
-					$(DIRSRC)core/gen_map.c	\
-					$(DIRSRC)prints.c			\
-					$(DIRSRC)attr.c			\
-					$(DIRSRC)cursor.c			\
-					$(DIRSRC)player.c			\
-					$(DIRSRC)enemy.c			\
-					$(DIRSRC)main.c
+SRC		+=	$(DIRLIB)paths.c		\
+			$(DIRLIB)readline.c		\
+			$(DIRLIB)objects/*.c		\
+			$(DIRSRC)core/files.c		\
+			$(DIRSRC)core/gen_map.c		\
+			$(DIRSRC)prints.c		\
+			$(DIRSRC)attr.c			\
+			$(DIRSRC)cursor.c		\
+			$(DIRSRC)player.c		\
+			$(DIRSRC)enemy.c		\
+			$(DIRSRC)main.c
 
-OBJ		=		$(SRC:.c=.o)
+OBJ		=	$(SRC:.c=.o)
 
-EXEC		=		fita
+EXEC		=	fita
 
-all:				$(EXEC)
+all:		$(EXEC)
 
-$(EXEC):			$(OBJ)
-					$(CC) -o $(EXEC) $(OBJ) $(LDFLAGS) $(CFLAGS)
-					make clean
-					mv $(EXEC) bin/
+$(EXEC):	$(OBJ)
+		$(CC) -o $(EXEC) $(OBJ) $(LDFLAGS)
+#		make clean
+#		mv $(EXEC) bin/
 
 clean:
-					rm -f $(OBJ)
+		rm -f $(OBJ)
 
-fclean:			clean
-					rm -f $(EXEC)
+fclean:		clean
+		rm -f $(EXEC)
 
-re:				clean all
+re:		fclean all
+
+.PHONY:		all clean fclean re

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,16 @@ CFLAGS		+=	-I $(DIRINC)	\
 
 LDFLAGS		+=	-lncurses
 
-DIRLIB		+=	./lib/
+DIRLIB		+=	lib/
 
-DIRSRC		+=	./src/
+DIRSRC		+=	src/
 
-DIRINC		+=	./include/
+DIRINC		+=	include/
 
 SRC		+=	$(DIRLIB)paths.c		\
 			$(DIRLIB)readline.c		\
-			$(DIRLIB)objects/*.c		\
+			$(DIRLIB)objects/string.c	\
+			$(DIRLIB)objects/o_strings.c	\
 			$(DIRSRC)core/files.c		\
 			$(DIRSRC)core/gen_map.c		\
 			$(DIRSRC)prints.c		\


### PR DESCRIPTION
- Fix (maybe, preview is broken) indentation bug
- add .gitignore
- comment line:
           - `make clean` -> not a good practice to automatically remove object files because each `make` will recompile ALL source files instead of only modified files
           - ` mv $(EXEC) bin/` -> seem like useless command because /bin doesn't exist originally
- remove "hardcode" `$CFLAGS` on linking line : the "magic" variable CFLAGS is automatically add, hardcode it is not a good pratice.